### PR TITLE
Fix/widget css

### DIFF
--- a/frontend/src/components/Chat/Chat.scss
+++ b/frontend/src/components/Chat/Chat.scss
@@ -157,7 +157,7 @@
     
     #message-list {
       padding-top: 0;
-      margin-bottom: 20vh;
+      margin-bottom: 22vh;
       width: 20vw; 
       .chat-list-item {
         width: 19vw;

--- a/frontend/src/components/Chat/Chat.scss
+++ b/frontend/src/components/Chat/Chat.scss
@@ -45,10 +45,12 @@
     background-color: $chat-background-color;
     font-family: 'Ubuntu', sans-serif;
     .chat-username-item {
+      overflow-wrap: break-word;
       word-break: keep-all;
     }
     .message-item {
-      word-break: break-all;
+      overflow-wrap: break-word;
+      word-break: break-word;
       width: 98vw;
       
     }

--- a/frontend/src/components/Room.scss
+++ b/frontend/src/components/Room.scss
@@ -111,6 +111,10 @@
     width: 80vw;
   }
 
+  .youtube-widget {
+    flex-direction: column;
+  }
+
   #nav-toggle {
     width: 80vw;
   }
@@ -132,7 +136,6 @@
 
   .youtube-widget {
     display: flex;
-    flex-direction: column;
     flex-grow: 1;
     min-width: 0;
   }

--- a/frontend/src/components/Room.scss
+++ b/frontend/src/components/Room.scss
@@ -11,6 +11,10 @@
   @include custom-scrollbar;
 }
 
+.youtube-widget {
+  flex-direction: column;
+}
+
 .canvas-container {
   margin-left: 1vw;
 
@@ -109,10 +113,6 @@
 @media only screen and (min-width: 768px) {
   .widget-container {
     width: 80vw;
-  }
-
-  .youtube-widget {
-    flex-direction: column;
   }
 
   #nav-toggle {

--- a/frontend/src/components/Room.scss
+++ b/frontend/src/components/Room.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   margin-bottom: 100vh;
-  height: 70vh;
+  height: 200vh;
   width: 100vw;
   background-color: $app-bg-color;
   @include custom-scrollbar;
@@ -112,6 +112,7 @@
 /* Tablet CSS */
 @media only screen and (min-width: 768px) {
   .widget-container {
+    height: 80vh;
     width: 80vw;
   }
 
@@ -123,7 +124,6 @@
 @media only screen and (min-width: 1080px) {
   .widget-container {
     flex-direction: row;
-    height: 80vh;
     margin-bottom: 20vh;
   }
 

--- a/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
+++ b/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
@@ -1,0 +1,8 @@
+const MinimizeToggle = (props) => {
+  if (props.bool) {
+    return (<><i className="fa-solid fa-window-minimize"/> <i class="fa-regular fa-comment" /></>);
+  }
+  return (<><i className="fa-solid fa-plus" /> <i class="fa-regular fa-comment" /></>);
+};
+
+export default MinimizeToggle;

--- a/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
+++ b/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
@@ -1,8 +1,8 @@
 const MinimizeToggle = (props) => {
   if (props.bool) {
-    return (<><i className="fa-solid fa-window-minimize"/> <i class="fa-regular fa-comment" /></>);
+    return (<><i className="fa-solid fa-window-minimize"/> <i className="fa-regular fa-comment" /></>);
   }
-  return (<><i className="fa-solid fa-plus" /> <i class="fa-regular fa-comment" /></>);
+  return (<><i className="fa-solid fa-plus" /> <i className="fa-regular fa-comment" /></>);
 };
 
 export default MinimizeToggle;

--- a/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
+++ b/frontend/src/components/apis/Twitch/MinimizeToggle.jsx
@@ -1,6 +1,6 @@
 const MinimizeToggle = (props) => {
   if (props.bool) {
-    return (<><i className="fa-solid fa-window-minimize"/> <i className="fa-regular fa-comment" /></>);
+    return (<><i className="fa-solid fa-minus"/> <i className="fa-regular fa-comment" /></>);
   }
   return (<><i className="fa-solid fa-plus" /> <i className="fa-regular fa-comment" /></>);
 };

--- a/frontend/src/components/apis/Twitch/SearchBar.scss
+++ b/frontend/src/components/apis/Twitch/SearchBar.scss
@@ -20,7 +20,7 @@
 
 .radius {
   border-radius: 0.5rem;
-  width: 20em;
+  width: 15em;
   height: 2.3em;
   text-align: center;
 }
@@ -28,4 +28,9 @@
 ::placeholder {
   text-align: center;
   color: #c9c9c9;
+}
+@media only screen and (min-width: 768px) {
+  .radius {
+    width: 20em;
+  }
 }

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -49,28 +49,31 @@
   margin-top: 0.5rem;
   display: flex;
   position: relative;
-  flex-direction: row;
+  flex-direction: column;
   width: 100vw;
   .twitch-video-frame {
-    display: flex;
-    flex-grow: 2;
+    flex-grow: 1;
     height: 50vh;
+    min-width: 60%;
   }
 
   .twitch-chat-frame {
-    flex-grow: 0.5;
-    width: inherit;
+    flex-grow: 1;
+    width: 100%;
+    height: 50vh;
   }
 }
 /* Tablet CSS */
 @media only screen and (min-width: 768px) {
   .stream-frames {
-    width: 80vw;
+    flex-direction: row;
+    width: inherit;
     .twitch-video-frame {
       height: 70vh;
     }
     .twitch-chat-frame {
       height: 70vh;
+      width: 40%;
     }
   }
 

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -67,7 +67,7 @@
 @media only screen and (min-width: 768px) {
   .min-twitch-btn {
     display: flex;
-    align-items: center;
+    gap: 0.2em;
     top: -2em;
     left: auto;
     right: 1em;
@@ -88,7 +88,7 @@
 }
 @media only screen and (min-width: 1080px) {
   .min-twitch-btn {
-    left: 38vw;
+    left: 40vw;
   }
 
   .twitch-chat-frame {

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -9,8 +9,8 @@
 .min-twitch-btn {
   position: absolute;
   z-index: 1;
-  top: -2rem;
-  left: 90vw;
+  top: 81vh;
+  left: 0vw;
   color: #FFFFFF;
   background: none;
   border: none;
@@ -66,7 +66,11 @@
 /* Tablet CSS */
 @media only screen and (min-width: 768px) {
   .min-twitch-btn {
-    left: 77vw;
+    display: flex;
+    align-items: center;
+    top: -2em;
+    left: auto;
+    right: 1em;
   }
 
   .stream-frames {

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -102,4 +102,8 @@
       width: 35%;
     }
   }
+
+  .result-list {
+    width: 25em;
+  }
 }

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -69,8 +69,8 @@
     display: flex;
     gap: 0.2em;
     top: -2em;
-    left: auto;
-    right: 1em;
+    left: 1em;
+    right: auto;
   }
 
   .stream-frames {
@@ -87,9 +87,6 @@
 
 }
 @media only screen and (min-width: 1080px) {
-  .min-twitch-btn {
-    left: 40vw;
-  }
 
   .twitch-chat-frame {
     width: 10em;

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -7,17 +7,27 @@
 }
 
 .min-twitch-btn {
-  display: flex;
-  align-self: end;
+  position: absolute;
+  z-index: 1;
+  top: 0.2rem;
+  right: 0.2rem;
+  color: #FFFFFF;
+  background: none;
+  border: none;
+  &:hover {
+    color: dodgerblue;
+  }
 }
 
 .result-list {
   background-color: $channel-bg-color;
   display: flex;
   position: absolute;
-  left: 35vw;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
   height: 35vh;
-  width: 40vw;
+  width: 20em;
   flex-direction: column;
   overflow-y: scroll;
 
@@ -36,31 +46,24 @@
 }
 
 .twitch-chat-container {
-  display: inline;
+  display: flex;
   position: relative;
-  min-width: 2rem;
-  button {
-    position: absolute;
-    color: #FFFFFF;
-    background: none;
-    border: none;
-  }
-  button:hover {
-    color: dodgerblue;
-  }
 }
 
 .stream-frames {
   margin-top: 0.5rem;
   display: flex;
+  position: relative;
   flex-direction: row;
   width: 100vw;
   .twitch-video-frame {
+    display: flex;
     flex-grow: 1;
     height: 50vh;
   }
   .twitch-chat-frame {
-    flex-grow: 0.2;
+    width: inherit;
+    min-width: 0;
     height: 50vh;
   }
 }
@@ -76,22 +79,11 @@
     }
   }
 
-  .result-list {
-    left: 25vw;
-    width: 30vw;
-  }
 }
 @media only screen and (min-width: 1080px) {
-  .twitch-live-search {
-    width: 40vw;
-  }
-
-  .result-list {
-    left: 5vw;
-  }
 
   .twitch-chat-container {
-    min-width: 1.5rem;
+    display: flex;
   }
 
   .stream-frames {
@@ -99,10 +91,6 @@
     .twitch-video-frame {
       flex-grow: 1;
       min-width: none;
-    }
-    .twitch-chat-frame {
-      min-width: none;
-      flex-grow: 1;
     }
   }
 }

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -53,14 +53,14 @@
   width: 100vw;
   .twitch-video-frame {
     flex-grow: 1;
-    height: 50vh;
+    height: 80vh;
     min-width: 60%;
   }
 
   .twitch-chat-frame {
     flex-grow: 1;
     width: 100%;
-    height: 50vh;
+    height: 80vh;
   }
 }
 /* Tablet CSS */

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -45,11 +45,6 @@
   }
 }
 
-.twitch-chat-container {
-  display: flex;
-  position: relative;
-}
-
 .stream-frames {
   margin-top: 0.5rem;
   display: flex;
@@ -58,13 +53,13 @@
   width: 100vw;
   .twitch-video-frame {
     display: flex;
-    flex-grow: 1;
+    flex-grow: 2;
     height: 50vh;
   }
+
   .twitch-chat-frame {
+    flex-grow: 0.5;
     width: inherit;
-    min-width: 0;
-    height: 50vh;
   }
 }
 /* Tablet CSS */
@@ -82,15 +77,18 @@
 }
 @media only screen and (min-width: 1080px) {
 
-  .twitch-chat-container {
-    display: flex;
+  .twitch-chat-frame {
+    width: 10em;
+    min-width: 0;
   }
 
   .stream-frames {
     width: inherit;
     .twitch-video-frame {
-      flex-grow: 1;
-      min-width: none;
+      min-width: 0;
+    }
+    .twitch-chat-frame {
+      min-width: 0;
     }
   }
 }

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -9,8 +9,8 @@
 .min-twitch-btn {
   position: absolute;
   z-index: 1;
-  top: 0.2rem;
-  right: 0.2rem;
+  top: -2rem;
+  left: 90vw;
   color: #FFFFFF;
   background: none;
   border: none;
@@ -65,6 +65,10 @@
 }
 /* Tablet CSS */
 @media only screen and (min-width: 768px) {
+  .min-twitch-btn {
+    left: 77vw;
+  }
+
   .stream-frames {
     flex-direction: row;
     width: inherit;
@@ -79,6 +83,9 @@
 
 }
 @media only screen and (min-width: 1080px) {
+  .min-twitch-btn {
+    left: 38vw;
+  }
 
   .twitch-chat-frame {
     width: 10em;
@@ -87,11 +94,8 @@
 
   .stream-frames {
     width: inherit;
-    .twitch-video-frame {
-      min-width: 0;
-    }
     .twitch-chat-frame {
-      min-width: 0;
+      width: 35%;
     }
   }
 }

--- a/frontend/src/components/apis/Twitch/Twitch.scss
+++ b/frontend/src/components/apis/Twitch/Twitch.scss
@@ -102,8 +102,4 @@
       width: 35%;
     }
   }
-
-  .result-list {
-    width: 25em;
-  }
 }

--- a/frontend/src/components/apis/Twitch/index.jsx
+++ b/frontend/src/components/apis/Twitch/index.jsx
@@ -27,7 +27,7 @@ function Twitch() {
             title={room.name}>
           </iframe>
           <div className='twitch-chat-container'>
-          <button class="min-twitch-btn" onClick={minimize}>{viewChat ? <i className="fa-solid fa-window-minimize"></i> : <i className="fa-solid fa-plus"></i>}</button>
+          <button className="min-twitch-btn" onClick={minimize}>{viewChat ? <i className="fa-solid fa-window-minimize"></i> : <i className="fa-solid fa-plus"></i>}</button>
             {viewChat && (
                 <iframe
                 className='twitch-chat-frame'

--- a/frontend/src/components/apis/Twitch/index.jsx
+++ b/frontend/src/components/apis/Twitch/index.jsx
@@ -18,6 +18,7 @@ function Twitch() {
       <LiveSearch />
       {room.channel && (
         <div className='stream-frames'>
+          <button className="min-twitch-btn" onClick={minimize}>{viewChat ? <i className="fa-solid fa-window-minimize"></i> : <i className="fa-solid fa-plus"></i>}</button>
           <iframe
             className='twitch-video-frame'
             display='inline'
@@ -27,7 +28,6 @@ function Twitch() {
             title={room.name}>
           </iframe>
           <div className='twitch-chat-container'>
-          <button className="min-twitch-btn" onClick={minimize}>{viewChat ? <i className="fa-solid fa-window-minimize"></i> : <i className="fa-solid fa-plus"></i>}</button>
             {viewChat && (
                 <iframe
                 className='twitch-chat-frame'

--- a/frontend/src/components/apis/Twitch/index.jsx
+++ b/frontend/src/components/apis/Twitch/index.jsx
@@ -27,7 +27,6 @@ function Twitch() {
             allowFullScreen
             title={room.name}>
           </iframe>
-          <div className='twitch-chat-container'>
             {viewChat && (
                 <iframe
                 className='twitch-chat-frame'
@@ -37,7 +36,6 @@ function Twitch() {
                 height="480"
                 title={room.name}>
               </iframe>)}
-          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/apis/Twitch/index.jsx
+++ b/frontend/src/components/apis/Twitch/index.jsx
@@ -3,6 +3,7 @@ import LiveSearch from "./LiveSearch";
 import './Twitch.scss';
 import { roomContext } from '../../../providers/RoomProvider';
 import { useState } from 'react';
+import MinimizeToggle from './MinimizeToggle';
 
 function Twitch() {
   const { room } = useContext(roomContext);
@@ -18,7 +19,7 @@ function Twitch() {
       <LiveSearch />
       {room.channel && (
         <div className='stream-frames'>
-          <button className="min-twitch-btn" onClick={minimize}>{viewChat ? <i className="fa-solid fa-window-minimize"></i> : <i className="fa-solid fa-plus"></i>}</button>
+          <button className="min-twitch-btn" onClick={minimize}><MinimizeToggle bool={viewChat} /></button>
           <iframe
             className='twitch-video-frame'
             display='inline'

--- a/frontend/src/components/apis/Youtube/Youtube.scss
+++ b/frontend/src/components/apis/Youtube/Youtube.scss
@@ -21,9 +21,11 @@
   background-color: $channel-bg-color;
   display: flex;
   position: absolute;
-  left: 30vw;
+  left: 0;
+  right: 0;
   height: 35vh;
-  width: 40vw;
+  width: 20em;
+  margin: 0 auto;
   flex-direction: column;
   overflow-y: scroll;
   .video-article {
@@ -60,21 +62,9 @@
       height: 70vh;
     }
   }
-
-  .youtube-results {
-    left: 25vw;
-    width: 30vw;
-  }
 }
 
 @media only screen and (min-width: 1080px) {
-  .youtube-search {
-    width: 35vw;
-  }
-
-  .youtube-results {
-    left: 5vw;
-  }
 
   .youtube-video {
     iframe {

--- a/frontend/src/components/apis/Youtube/Youtube.scss
+++ b/frontend/src/components/apis/Youtube/Youtube.scss
@@ -73,4 +73,8 @@
       flex-grow: 1;
     }
   }
+
+  .youtube-results {
+    width: 25em;
+  }
 }

--- a/frontend/src/components/apis/Youtube/Youtube.scss
+++ b/frontend/src/components/apis/Youtube/Youtube.scss
@@ -50,6 +50,7 @@
   iframe {
     width: inherit;
     flex-grow: 1;
+    height: 80vh;
   }
 }
 

--- a/frontend/src/components/apis/Youtube/Youtube.scss
+++ b/frontend/src/components/apis/Youtube/Youtube.scss
@@ -73,8 +73,4 @@
       flex-grow: 1;
     }
   }
-
-  .youtube-results {
-    width: 25em;
-  }
 }

--- a/frontend/src/components/apis/Youtube/index.jsx
+++ b/frontend/src/components/apis/Youtube/index.jsx
@@ -50,7 +50,6 @@ function Youtube(props) {
         });
     });
     socket.on('setJoinerYoutubeTime', (res) => {
-      console.log('setting', res.time);
       playRef.current.internalPlayer.seekTo(res.time);
     });
     socket.on('serveVideo', (res) => {

--- a/frontend/src/components/apis/Youtube/index.jsx
+++ b/frontend/src/components/apis/Youtube/index.jsx
@@ -111,7 +111,7 @@ function Youtube(props) {
 
   return (
     <div className='youtube-widget' style={{ display: props.selected ? 'flex' : 'none' }}>
-      <div className='youtube-search' style={{ display: props.selected ? 'block' : 'none' }}>
+      <div className='youtube-search' >
         <form className='search__form' onSubmit={e => e.preventDefault()}>
           <input className='radius' type='text' value={term} placeholder='Search Youtube' onChange={(e) => setTerm(e.target.value)} />
         </form>

--- a/frontend/src/components/apis/Youtube/index.jsx
+++ b/frontend/src/components/apis/Youtube/index.jsx
@@ -110,8 +110,8 @@ function Youtube(props) {
   }
 
   return (
-    <div className='youtube-widget'>
-      <div className='youtube-search' style={{ display: props.selected ? 'block' : 'none' }}>
+    <div className='youtube-widget' style={{ display: room.youtubeVideo.channel && props.selected ? 'flex' : 'none' }}>
+      <div className='youtube-search' style={{ display: props.selected ? 'flex' : 'none' }}>
         <form className='search__form' onSubmit={e => e.preventDefault()}>
           <input className='radius' type='text' value={term} placeholder='Search Youtube' onChange={(e) => setTerm(e.target.value)} />
         </form>

--- a/frontend/src/components/apis/Youtube/index.jsx
+++ b/frontend/src/components/apis/Youtube/index.jsx
@@ -110,8 +110,8 @@ function Youtube(props) {
   }
 
   return (
-    <div className='youtube-widget' style={{ display: room.youtubeVideo.channel && props.selected ? 'flex' : 'none' }}>
-      <div className='youtube-search' style={{ display: props.selected ? 'flex' : 'none' }}>
+    <div className='youtube-widget' style={{ display: props.selected ? 'flex' : 'none' }}>
+      <div className='youtube-search' style={{ display: props.selected ? 'block' : 'none' }}>
         <form className='search__form' onSubmit={e => e.preventDefault()}>
           <input className='radius' type='text' value={term} placeholder='Search Youtube' onChange={(e) => setTerm(e.target.value)} />
         </form>


### PR DESCRIPTION
A lot of major fixes to the CSS, covered in here are:
* Chat messages break on words when possible rather than mid-word
* Twitch chat is no longer half the twitch view, and shares in all sizes
* Widgets expand without errors to fill screen when wanted
* Cleaned up a console log
* Minimize button is moved somewhere appropriate for all devices
*  Minimize button made more clear visually
* The results windows are uniform to the search field, preventing clipping for some screen sizes
* general responsive design improvements, twitch chat more accessible for mobile
